### PR TITLE
Add Windows installer configuration to builder.cjs

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -122,7 +122,24 @@ const config = {
 		icon: buildInfo.env === 'development' ? './build/dev_lin.png' : './build/icon_lin.png'
 	},
 	win: {
-		target: ['zip']
+		target: [
+			{
+				target: 'nsis',
+				arch: ['x64']
+			},
+			{
+				target: 'zip',
+				arch: ['x64']
+			}
+		]
+	},
+	nsis: {
+		oneClick: false,
+		perMachine: true,
+		allowElevation: true,
+		allowToChangeInstallationDirectory: true,
+		createDesktopShortcut: true,
+		createStartMenuShortcut: true
 	},
 	files: ['dist', 'public', 'package.json', 'LICENSE']
 };


### PR DESCRIPTION
This PR adds a configuration change to the builder.cjs file to build an installer for windows alongside the zip file. Fixes #34 

![image](https://github.com/relagit/relagit/assets/57594516/90f77486-5b76-4d5f-9a2e-7f584d7cc587)
