### PR TITLE
Fix RelaGit not being able to detect git install

### DIFF
--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -113,7 +113,7 @@ export default (window: BrowserWindow) => {
 
 	ipcMain.handle(ipc.CHECK_IS_IN_PATH, (_, bin: string) => {
 		try {
-			const command = process.platform === 'win32' ? 'where' : 'which';
+			const command = process.platform === 'win32' ? 'where.exe' : 'which';
 
 			const path = child_process.execSync(`${command} ${bin}`, {
 				env: preloadPathEnv()


### PR DESCRIPTION
This changes the command that checks for git's location from `where git` to `where.exe git`, which in my testing fixes th error that RelaGit wasn't able to detect a git installation for some users, including myself