### PR TITLE
Add fallback for ready-to-show event.

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -35,6 +35,7 @@ app.setAboutPanelOptions({
 
 const listeners: ((window: BrowserWindow) => void)[] = [];
 let loaded = false;
+let windowShown = false;
 
 // TODO: Fix auto-updater
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -140,14 +141,20 @@ const constructWindow = async () => {
 	}
 
 	win.once('ready-to-show', () => {
-		win.show();
+		if (!windowShown) {
+			windowShown = true;
+			win.show();
+		}
 	});
 
 	win.webContents.once('did-finish-load', () => {
+		if (!windowShown) {
+			windowShown = true;
+			win.show();
+		}
+
 		if (loaded) return;
-
 		loaded = true;
-
 		for (const listener of listeners) {
 			listener(win);
 		}


### PR DESCRIPTION
The `ready-to-show` event isn't consistently firing on Windows platforms, causing the window to not be shown sometimes.

This solution uses either `ready-to-show` or `did-finish-load` event (whichever fires first) to show the window. This should fix #23.

Based on the Electron issue (https://github.com/electron/electron/issues/25253), it seems either event may or may not be called depending on the platform.