### PR TITLE
feat: add stash picker with diff preview support

### DIFF
--- a/packages/app/src/modules/actions/def.d.ts
+++ b/packages/app/src/modules/actions/def.d.ts
@@ -71,7 +71,7 @@ interface Context {
 		CreateBranch: (repository: Repository | undefined, branch: string) => Promise<void>;
 		PushWithOrigin: (repository: Repository | undefined, branch: string) => Promise<void>;
 		Stash: (repository: Repository | undefined) => Promise<void>;
-		ListStash: (repository: Repository | undefined) => Promise<Record<number, string[]>>;
+		ListStash: (repository: Repository | undefined) => Promise<import('../git/stash').StashEntry[]>;
 		PopStash: (repository: Repository | undefined, stash: GitFile) => Promise<void>;
 		RemoveStash: (repository: Repository | undefined, stash: GitFile) => Promise<void>;
 		PreviousCommit: (repository: Repository | undefined, sha?: string) => Promise<string>;

--- a/packages/app/src/modules/git/index.ts
+++ b/packages/app/src/modules/git/index.ts
@@ -1,5 +1,5 @@
 export { ListBranches, Checkout, CreateBranch, DeleteBranch, PushWithOrigin } from './branches';
-export { Stash, ListStash, PopStash, RemoveStash } from './stash';
+export { Stash, ListStash, ShowStash, PopStash, RemoveStash } from './stash';
 export { Show, ShowOrigin, Details } from './show';
 export { PreviousCommit } from './previous-commit';
 export { SubmoduleStatus } from './submodule';

--- a/packages/app/src/modules/git/stash.ts
+++ b/packages/app/src/modules/git/stash.ts
@@ -1,6 +1,28 @@
 import { Repository } from '@stores/repository';
 
 import { Git } from './core';
+import { GitStatus } from './diff';
+import { GitDiff, parseDiff } from './parse-diff';
+
+const path = window.Native.DANGEROUS__NODE__REQUIRE('path');
+
+export interface StashDiff {
+	files: {
+		filename: string;
+		path: string;
+		diff: GitDiff;
+		status: GitStatus;
+		from?: string;
+		fromPath?: string;
+	}[];
+}
+
+export interface StashEntry {
+	index: number;
+	message: string;
+	branch: string;
+	files: string[];
+}
 
 export const Stash = async (repository: Repository | undefined) => {
 	if (!repository) return;
@@ -16,8 +38,8 @@ export const Stash = async (repository: Repository | undefined) => {
 
 export const ListStash = async (
 	repository: Repository | undefined
-): Promise<Record<number, string[]>> => {
-	if (!repository) return {};
+): Promise<StashEntry[]> => {
+	if (!repository) return [];
 
 	const res = await Git({
 		directory: repository.path,
@@ -29,7 +51,7 @@ export const ListStash = async (
 
 	const stashes = res.split('stash@').slice(1);
 
-	const stashMap: Record<number, string[]> = {};
+	const stashEntries: StashEntry[] = [];
 
 	for (let i = 0; i < stashes.length; i++) {
 		const stash = stashes[i];
@@ -38,9 +60,20 @@ export const ListStash = async (
 
 		const lines = stash.split('\n');
 
+		// First line contains: {index}: On <branch>: <message> or {index}: WIP on <branch>: <hash> <message>
+		const headerLine = lines[0];
+		let message = '';
+		let branch = '';
+
+		const headerMatch = headerLine.match(/\}:\s*(?:WIP\s+)?[Oo]n\s+([^:]+):\s*(.*)/);
+		if (headerMatch) {
+			branch = headerMatch[1].trim();
+			message = headerMatch[2].trim();
+		}
+
 		const files: string[] = [];
 
-		for (let j = 0; j < lines.length; j++) {
+		for (let j = 1; j < lines.length; j++) {
 			const line = lines[j];
 
 			const [, file] = line.split('\t');
@@ -48,10 +81,77 @@ export const ListStash = async (
 			if (file) files.push(file);
 		}
 
-		stashMap[index] = files;
+		stashEntries.push({ index, message, branch, files });
 	}
 
-	return stashMap;
+	return stashEntries;
+};
+
+export const ShowStash = async (
+	repository: Repository | undefined,
+	index: number
+): Promise<StashDiff | undefined> => {
+	if (!repository) return undefined;
+
+	const res = await Git({
+		directory: repository.path,
+		command: 'stash',
+		args: ['show', '-p', `stash@{${index}}`]
+	});
+
+	if (!res) return undefined;
+
+	const stashDiff: StashDiff = { files: [] };
+
+	const files = res.split(/^diff --git/gm);
+
+	for (let i = 0; i < files.length; i++) {
+		const file = files[i];
+
+		const isRename = file.includes('rename from') && file.includes('rename to');
+
+		if (file.length === 0) continue;
+
+		if (!isRename) {
+			const [name, ...diff] = file.split('\n');
+
+			const _diff = parseDiff('diff --git ' + name + '\n' + diff.join('\n'));
+
+			const p = path.dirname(name.replace('a/', '').split(' b/').pop()!);
+
+			let status: GitStatus | undefined = undefined;
+
+			if (_diff.files[0]?.type === 'AddedFile') status = 'added';
+			if (_diff.files[0]?.type === 'ChangedFile') status = 'modified';
+			if (_diff.files[0]?.type === 'DeletedFile') status = 'deleted';
+			if (_diff.files[0]?.type === 'RenamedFile') status = 'renamed';
+
+			stashDiff.files.push({
+				filename: path.basename(name.replace('a/', '').split(' b/').pop()!),
+				path: p === '.' ? '' : p,
+				diff: _diff,
+				status: status ?? 'modified'
+			});
+		} else {
+			const [name, , from, to, ...diff] = file.split('\n');
+
+			const _diff = parseDiff('diff --git ' + name + '\n' + diff.join('\n'));
+
+			const toFile = to.match(/rename to (.*)/)?.[1];
+			const fromFile = from.match(/rename from (.*)/)?.[1];
+
+			stashDiff.files.push({
+				filename: path.basename(toFile!),
+				path: path.dirname(toFile!),
+				diff: _diff,
+				status: 'renamed',
+				from: path.basename(fromFile!),
+				fromPath: path.dirname(fromFile!)
+			});
+		}
+	}
+
+	return stashDiff;
 };
 
 export const PopStash = async (repository: Repository | undefined, index: number) => {

--- a/packages/app/src/modules/i18n/locales/de.ts
+++ b/packages/app/src/modules/i18n/locales/de.ts
@@ -213,6 +213,8 @@ export default {
 		divergedHint: 'Änderungen stashen und pullen',
 		nothingToSee: 'Hier gibt es nichts zu sehen',
 		popStash: 'Pop Stash',
+		stashes: 'Stashes',
+		stashCount: ['{{count}} Stash', '{{count}} Stashes'],
 		commits: ['{{count}} commit', '{{count}} commits'],
 		stashedChanges: ['{{count}} Änderung stashed', '{{count}} Änderungen stashed']
 	},

--- a/packages/app/src/modules/i18n/locales/en-US.ts
+++ b/packages/app/src/modules/i18n/locales/en-US.ts
@@ -340,6 +340,8 @@ export default {
 		divergedHint: 'Stash changes and pull',
 		nothingToSee: 'Nothing to see here',
 		popStash: 'Pop Stash',
+		stashes: 'Stashes',
+		stashCount: ['{{count}} stash', '{{count}} stashes'],
 		commits: ['{{count}} commit', '{{count}} commits'],
 		stashedChanges: ['{{stashCount}} stash ({{count}})', '{{stashCount}} stashes ({{count}})'],
 		removeStash: 'Remove Stash',

--- a/packages/app/src/modules/i18n/locales/es.ts
+++ b/packages/app/src/modules/i18n/locales/es.ts
@@ -306,6 +306,8 @@ export default {
 		divergedHint: 'Guarda los cambios y obtén',
 		nothingToSee: 'Nada que ver aquí',
 		popStash: 'Recuperar cambios guardados',
+		stashes: 'Cambios guardados',
+		stashCount: ['{{count}} cambio guardado', '{{count}} cambios guardados'],
 		commits: ['{{count}} confirmación', '{{count}} confirmaciones'],
 		stashedChanges: [
 			'{{stashCount}} cambio guardado ({{count}})',

--- a/packages/app/src/modules/i18n/locales/fr.ts
+++ b/packages/app/src/modules/i18n/locales/fr.ts
@@ -343,6 +343,8 @@ export default {
 		divergedHint: 'Mettez les modifications en réserve et tirez',
 		nothingToSee: 'Rien à voir ici',
 		popStash: 'Récupérer la réserve',
+		stashes: 'Réserves',
+		stashCount: ['{{count}} réserve', '{{count}} réserves'],
 		commits: ['{{count}} commit', '{{count}} commits'],
 		stashedChanges: [
 			'{{stashCount}} réserve ({{count}})',

--- a/packages/app/src/modules/i18n/locales/lat.ts
+++ b/packages/app/src/modules/i18n/locales/lat.ts
@@ -207,6 +207,8 @@ export default {
 		divergedHint: 'Stash Mutationes et pull',
 		nothingToSee: 'Nihil hic videre',
 		popStash: 'Pop Stash',
+		stashes: 'Stashes',
+		stashCount: ['{{count}} stash', '{{count}} stashes'],
 		commits: ['{{count}} commit', '{{count}} commits'],
 		stashedChanges: ['{{count}} stashed mutatio', '{{count}} stashed mutationes']
 	},

--- a/packages/app/src/modules/i18n/locales/zh.ts
+++ b/packages/app/src/modules/i18n/locales/zh.ts
@@ -325,6 +325,8 @@ export default {
 		divergedHint: '储藏更改并拉取',
 		nothingToSee: '这里没有任何内容',
 		popStash: '弹出储藏',
+		stashes: '储藏',
+		stashCount: ['{{count}}个储藏', '{{count}}个储藏'],
 		commits: ['{{count}}个提交', '{{count}}个提交'],
 		stashedChanges: [
 			'{{stashCount}}个储藏（{{count}}个）',

--- a/packages/app/src/stores/location.ts
+++ b/packages/app/src/stores/location.ts
@@ -15,6 +15,7 @@ const LocationStore = new (class LocationStore extends GenericStore {
 	#selectedFile: GitFile | undefined = undefined;
 	#selectedRepository: Repository | undefined = undefined;
 	#historyOpen = false;
+	#stashOpen = false;
 	#selectedCommit: LogCommit | undefined = undefined;
 	#selectedCommitFiles: PastCommit | undefined = undefined;
 	#selectedCommitFile: PastCommit['files'][number] | undefined = undefined;
@@ -71,6 +72,10 @@ const LocationStore = new (class LocationStore extends GenericStore {
 		return this.#historyOpen;
 	}
 
+	get stashOpen() {
+		return this.#stashOpen;
+	}
+
 	get isRefetchingSelectedRepository() {
 		return this.#isRefetchingSelectedRepository;
 	}
@@ -108,6 +113,13 @@ const LocationStore = new (class LocationStore extends GenericStore {
 
 	setHistoryOpen(open: boolean) {
 		this.#historyOpen = open;
+		if (open) this.#stashOpen = false;
+		this.emit();
+	}
+
+	setStashOpen(open: boolean) {
+		this.#stashOpen = open;
+		if (open) this.#historyOpen = false;
 		this.emit();
 	}
 
@@ -139,6 +151,7 @@ const LocationStore = new (class LocationStore extends GenericStore {
 		this.#selectedCommit = undefined;
 		this.#selectedCommitFiles = undefined;
 		this.#selectedCommitFile = undefined;
+		this.#stashOpen = false;
 		this.#selectedRepository = repository;
 		this.emit();
 

--- a/packages/app/src/ui/Workspace/CodeView/index.tsx
+++ b/packages/app/src/ui/Workspace/CodeView/index.tsx
@@ -158,8 +158,10 @@ export default (props: CodeViewProps) => {
 	const commit = createStoreListener([LocationStore], () => LocationStore.selectedCommitFile);
 	const repo = createStoreListener([LocationStore], () => LocationStore.selectedRepository);
 	const historyOpen = createStoreListener([LocationStore], () => LocationStore.historyOpen);
+	const stashOpen = createStoreListener([LocationStore], () => LocationStore.stashOpen);
+	const diffOpen = () => historyOpen() || stashOpen();
 	const fileStatus = createStoreListener([FileStore, LocationStore], () =>
-		historyOpen?.() ? commit()?.status : FileStore.getStatus(props.repository, props.file)
+		diffOpen?.() ? commit()?.status : FileStore.getStatus(props.repository, props.file)
 	);
 
 	// only run these when needed
@@ -179,29 +181,31 @@ export default (props: CodeViewProps) => {
 		setThrew(null);
 
 		try {
-			if (LocationStore.historyOpen) {
+			if (LocationStore.historyOpen || LocationStore.stashOpen) {
 				setShowCommit(true);
 
 				if (!LocationStore.selectedCommitFile) {
 					return;
 				}
 
-				try {
-					if (LocationStore.selectedCommit?.hash)
-						setBlame(
-							await Git.Blame(
-								props.repository,
-								path.join(
-									LocationStore.selectedCommitFile.path,
-									LocationStore.selectedCommitFile.filename
-								),
-								LocationStore.selectedCommit?.hash
-							)
-						);
-				} catch (e) {
-					setBlame(null);
+				if (LocationStore.historyOpen) {
+					try {
+						if (LocationStore.selectedCommit?.hash)
+							setBlame(
+								await Git.Blame(
+									props.repository,
+									path.join(
+										LocationStore.selectedCommitFile.path,
+										LocationStore.selectedCommitFile.filename
+									),
+									LocationStore.selectedCommit?.hash
+								)
+							);
+					} catch (e) {
+						setBlame(null);
 
-					error(e);
+						error(e);
+					}
 				}
 
 				setDiff(LocationStore.selectedCommitFile?.diff);
@@ -342,7 +346,7 @@ export default (props: CodeViewProps) => {
 						}
 					>
 						<Show
-							when={(props.file && props.repository) || (historyOpen() && commit())}
+							when={(props.file && props.repository) || (diffOpen() && commit())}
 							fallback={
 								<>
 									<Show
@@ -550,7 +554,7 @@ export default (props: CodeViewProps) => {
 												<ImageView
 													repository={props.repository}
 													fromPath={
-														historyOpen() ?
+														diffOpen() ?
 															path.join(
 																commit()?.fromPath || '',
 																commit()?.from || ''
@@ -558,7 +562,7 @@ export default (props: CodeViewProps) => {
 														:	props.fromFile
 													}
 													path={
-														historyOpen() ?
+														diffOpen() ?
 															path.join(
 																props.repository,
 																commit()?.path || '',

--- a/packages/app/src/ui/Workspace/Header/index.scss
+++ b/packages/app/src/ui/Workspace/Header/index.scss
@@ -119,6 +119,78 @@
 	}
 }
 
+.popout .stash-picker {
+	user-select: none;
+	max-width: 350px;
+	overflow: hidden;
+
+	&__label {
+		color: var(--color-secondary);
+		font-size: 0.85rem;
+		padding: 16px 16px 8px;
+		font-weight: 600;
+		outline: none;
+	}
+
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+		max-height: 400px;
+		overflow-y: auto;
+
+		&__item {
+			background: none;
+			display: flex;
+			padding: 10px 16px;
+			align-items: center;
+			color: var(--color-primary);
+			border-top: 1px solid var(--separator-secondary);
+			justify-content: space-between;
+			text-align: left;
+			min-width: 250px;
+			width: 100%;
+			gap: 12px;
+
+			@include mixins.focusable;
+
+			&:hover {
+				background-color: var(--bg-hover);
+			}
+
+			&__content {
+				overflow: hidden;
+				display: flex;
+				flex-direction: column;
+				gap: 2px;
+
+				&__message {
+					color: var(--color-primary);
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					font-size: 0.9rem;
+				}
+
+				&__meta {
+					color: var(--color-secondary);
+					font-size: 0.8rem;
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
+			}
+
+			&__info {
+				color: var(--color-secondary);
+				font-size: 0.8rem;
+				white-space: nowrap;
+				flex-shrink: 0;
+			}
+		}
+	}
+}
+
 .popout .branches-picker {
 	user-select: none;
 	max-width: 300px;

--- a/packages/app/src/ui/Workspace/Header/index.tsx
+++ b/packages/app/src/ui/Workspace/Header/index.tsx
@@ -1,6 +1,7 @@
 import { For, JSX, Show, createEffect, createSignal } from 'solid-js';
 
 import { Branch } from '@app/modules/git/branches';
+import { StashEntry } from '@app/modules/git/stash';
 import { t } from '@app/modules/i18n';
 import { Reffable } from '@app/shared';
 import DraftStore from '@app/stores/draft';
@@ -111,7 +112,8 @@ export default () => {
 	const [newBranch, setNewBranch] = createSignal('');
 	const [inputRef, setInputRef] = createSignal<HTMLElement>();
 	const [branches, setBranches] = createSignal<Branch[] | null>(null);
-	const [stashes, setStashes] = createSignal<Record<number, string[]> | null>(null);
+	const [stashes, setStashes] = createSignal<StashEntry[] | null>(null);
+	const stashPickerSignal = createSignal(false);
 	const [status, setStatus] = createSignal<'publish' | 'diverged' | 'ahead' | 'behind' | null>(
 		null
 	);
@@ -435,79 +437,180 @@ export default () => {
 					}}
 				/>
 			</Menu>
-			<Show when={Object.keys(stashes() || {}).length > 0}>
-				<Menu
-					interfaceId="workspace-pop-stash"
-					items={[
-						{
-							type: 'item',
-							label: t('git.removeStash'),
-							disabled: !repository(),
-							onClick: async () => {
-								if (!repository()) return;
-
-								if (Object.keys(stashes() || {}).length === 0) return;
-
-								setStashActioning(true);
-
-								try {
-									await Git.RemoveStash(LocationStore.selectedRepository, 0);
-
-									setStashActioning(false);
-
-									refetchRepository(LocationStore.selectedRepository);
-								} catch (e) {
-									showErrorModal(e, 'error.git');
-
-									error(e);
-								}
-							}
-						}
-					]}
-				>
-					<PanelButton
-						icon="file-directory"
-						iconVariant={iconVariant()}
-						id="workspace-pop-stash"
-						onClick={async () => {
-							if (!repository()) return;
-
-							if (Object.keys(stashes() || {}).length === 0) return;
-
-							setStashActioning(true);
-
-							try {
-								await Git.PopStash(LocationStore.selectedRepository, 0);
-
-								triggerWorkflow('stash_pop', LocationStore.selectedRepository!);
-
-								setStashActioning(false);
-
-								refetchRepository(LocationStore.selectedRepository);
-							} catch (e) {
-								showErrorModal(e, 'error.git');
-
-								error(e);
-							}
-						}}
-						loading={stashActioning()}
-						label={t('git.popStash')}
-						detail={t(
-							'git.stashedChanges',
-							{
-								stashCount: Object.keys(stashes()!).length,
-								count: t(
-									'git.files',
+			<Show when={(stashes() || []).length > 0}>
+				<Popout
+					position="bottom"
+					align="end"
+					open={stashPickerSignal}
+					body={() => (
+						<div class="stash-picker">
+							<div class="stash-picker__label" tabIndex={0}>
+								{t(
+									'git.stashedChanges',
 									{
-										count: stashes()![0].length
+										stashCount: stashes()!.length,
+										count: t(
+											'git.files',
+											{
+												count: stashes()![0].files.length
+											},
+											stashes()![0].files.length
+										)
 									},
-									stashes()![0].length
-								)
-							},
-							Object.keys(stashes()!).length
-						)}
-					/>
-				</Menu>
+									stashes()!.length
+								)}
+							</div>
+							<div class="stash-picker__list">
+								<For each={stashes()}>
+									{(stash) => (
+										<Menu
+											interfaceId="workspace-stash-item"
+											items={[
+												{
+													type: 'item',
+													label: t('git.popStash'),
+													onClick: async () => {
+														if (!repository()) return;
+
+														setStashActioning(true);
+
+														try {
+															await Git.PopStash(
+																LocationStore.selectedRepository,
+																stash.index
+															);
+
+															triggerWorkflow(
+																'stash_pop',
+																LocationStore.selectedRepository!
+															);
+
+															stashPickerSignal[1](false);
+
+															refetchRepository(
+																LocationStore.selectedRepository
+															);
+														} catch (e) {
+															showErrorModal(e, 'error.git');
+															error(e);
+														} finally {
+															setStashActioning(false);
+														}
+													}
+												},
+												{
+													type: 'item',
+													label: t('git.removeStash'),
+													color: 'danger',
+													onClick: async () => {
+														if (!repository()) return;
+
+														setStashActioning(true);
+
+														try {
+															await Git.RemoveStash(
+																LocationStore.selectedRepository,
+																stash.index
+															);
+
+															refetchRepository(
+																LocationStore.selectedRepository
+															);
+														} catch (e) {
+															showErrorModal(e, 'error.git');
+															error(e);
+														} finally {
+															setStashActioning(false);
+														}
+													}
+												}
+											]}
+										>
+											<button
+												class="stash-picker__list__item"
+												onClick={async () => {
+													if (!repository()) return;
+
+													stashPickerSignal[1](false);
+
+													try {
+														const stashDiff = await Git.ShowStash(
+															LocationStore.selectedRepository,
+															stash.index
+														);
+
+														if (stashDiff) {
+															LocationStore.setStashOpen(true);
+															LocationStore.setSelectedCommit({
+																hash: `stash@{${stash.index}}`,
+																refs: '',
+																parent: '',
+																message:
+																	stash.message ||
+																	`stash@{${stash.index}}`,
+																author: stash.branch,
+																date: '',
+																files: stashDiff.files.length,
+																insertions: 0,
+																deletions: 0
+															});
+															LocationStore.setSelectedCommitFiles({
+																hash: `stash@{${stash.index}}`,
+																files: stashDiff.files
+															});
+															LocationStore.setSelectedCommitFile(
+																stashDiff.files[0]
+															);
+														}
+													} catch (e) {
+														showErrorModal(e, 'error.git');
+														error(e);
+													}
+												}}
+											>
+												<div class="stash-picker__list__item__content">
+													<div class="stash-picker__list__item__content__message">
+														{stash.message || `stash@${stash.index}`}
+													</div>
+													<div class="stash-picker__list__item__content__meta">
+														{stash.branch}
+													</div>
+												</div>
+												<div class="stash-picker__list__item__info">
+													{t(
+														'git.files',
+														{ count: stash.files.length },
+														stash.files.length
+													)}
+												</div>
+											</button>
+										</Menu>
+									)}
+								</For>
+							</div>
+						</div>
+					)}
+				>
+					{(p) => (
+						<PanelButton
+							ref={p.ref}
+							icon="file-directory"
+							iconVariant={iconVariant()}
+							id="workspace-stash-picker"
+							loading={stashActioning()}
+							className={p.open() ? 'active' : ''}
+							label={t('git.stashes')}
+							detail={t(
+								'git.stashCount',
+								{ count: stashes()!.length },
+								stashes()!.length
+							)}
+							onMouseDown={(e) => {
+								p.toggle(e);
+							}}
+						/>
+					)}
+				</Popout>
 			</Show>
 			<div class="workspace__header__spacer" />
 			<Popout

--- a/packages/app/src/ui/Workspace/index.scss
+++ b/packages/app/src/ui/Workspace/index.scss
@@ -28,6 +28,35 @@
 		user-select: none;
 		border-bottom: 1px solid var(--separator-secondary);
 
+		&__top {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 8px;
+		}
+
+		&__close {
+			background: none;
+			border: none;
+			color: var(--color-secondary);
+			cursor: pointer;
+			padding: 4px;
+			border-radius: 4px;
+			display: flex;
+			align-items: center;
+			flex-shrink: 0;
+
+			svg {
+				width: 16px;
+				height: 16px;
+			}
+
+			&:hover {
+				background-color: var(--bg-hover);
+				color: var(--color-primary);
+			}
+		}
+
 		&__message {
 			color: var(--color-primary);
 			font-size: 1.25rem;

--- a/packages/app/src/ui/Workspace/index.tsx
+++ b/packages/app/src/ui/Workspace/index.tsx
@@ -58,7 +58,23 @@ export default (props: WorkspaceProps) => {
 			<Header />
 			<Show when={diffOpen() && commit()}>
 				<div class="workspace__commit">
-					<div class="workspace__commit__message">{commit()!.message}</div>
+					<div class="workspace__commit__top">
+						<div class="workspace__commit__message">{commit()!.message}</div>
+						<Show when={stashOpen()}>
+							<button
+								class="workspace__commit__close"
+								aria-label={t('modal.close')}
+								onClick={() => {
+									LocationStore.setStashOpen(false);
+									LocationStore.setSelectedCommit(undefined);
+									LocationStore.setSelectedCommitFiles(undefined);
+									LocationStore.setSelectedCommitFile(undefined);
+								}}
+							>
+								<Icon name="x" />
+							</button>
+						</Show>
+					</div>
 					<div class="workspace__commit__details">
 						<div class="workspace__commit__details__author">{commit()!.author}</div>
 						<div class="workspace__commit__details__hash">

--- a/packages/app/src/ui/Workspace/index.tsx
+++ b/packages/app/src/ui/Workspace/index.tsx
@@ -45,6 +45,8 @@ export default (props: WorkspaceProps) => {
 	);
 	const commit = createStoreListener([LocationStore], () => LocationStore.selectedCommit);
 	const historyOpen = createStoreListener([LocationStore], () => LocationStore.historyOpen);
+	const stashOpen = createStoreListener([LocationStore], () => LocationStore.stashOpen);
+	const diffOpen = () => historyOpen() || stashOpen();
 	const selectedCommitFile = createStoreListener(
 		[LocationStore],
 		() => LocationStore.selectedCommitFile
@@ -54,7 +56,7 @@ export default (props: WorkspaceProps) => {
 	return (
 		<div classList={{ workspace: true, 'sidebar-active': props.sidebar }}>
 			<Header />
-			<Show when={historyOpen() && commit()}>
+			<Show when={diffOpen() && commit()}>
 				<div class="workspace__commit">
 					<div class="workspace__commit__message">{commit()!.message}</div>
 					<div class="workspace__commit__details">
@@ -95,7 +97,7 @@ export default (props: WorkspaceProps) => {
 				</div>
 			</Show>
 			<div class="workspace__container">
-				<Show when={historyOpen() && commitFiles()}>
+				<Show when={diffOpen() && commitFiles()}>
 					<div class="workspace__container__files">
 						<For each={commitFiles()?.files}>
 							{(commitFile) => (
@@ -263,21 +265,21 @@ export default (props: WorkspaceProps) => {
 					<div class="workspace__container__main__file">
 						<div class="workspace__container__main__file__path">
 							<Show
-								when={(historyOpen() ?
+								when={(diffOpen() ?
 									selectedCommitFile()?.path || ''
 								:	file()?.file?.path || ''
 								).endsWith('/')}
 								fallback={
-									((historyOpen() ?
+									((diffOpen() ?
 										selectedCommitFile()?.path
 									:	file()?.file?.path) || '') + '/'
 								}
 							>
-								{historyOpen() ? selectedCommitFile()?.path : file()?.file?.path}
+								{diffOpen() ? selectedCommitFile()?.path : file()?.file?.path}
 							</Show>
 						</div>
 						<div class="workspace__container__main__file__name">
-							{historyOpen() ? selectedCommitFile()?.filename : file()?.file?.name}
+							{diffOpen() ? selectedCommitFile()?.filename : file()?.file?.name}
 						</div>
 					</div>
 					<CodeView


### PR DESCRIPTION
## Summary
  - Replace the single "Pop Stash" button with a popout stash picker that lists all stashes with their message, branch, and
   file count
  - Clicking a stash now shows its diff in the workspace (like viewing a commit) instead of immediately popping it
  - Pop and Remove actions are available via right-click context menu on each stash item
  - Add `ShowStash` git function using `git stash show -p` to fetch and parse stash diffs
  - Add i18n support for stash picker labels across all 6 locales

  ## Test plan
  - [ ] Create multiple stashes and verify they all appear in the stash picker dropdown
  - [ ] Click a stash item and verify its diff is displayed in the workspace
  - [ ] Right-click a stash and verify "Pop Stash" applies the correct stash
  - [ ] Right-click a stash and verify "Remove Stash" drops the correct stash
  - [ ] Verify loading state clears properly on both success and error
  - [ ] Verify stash picker closes after selecting a stash
  
  ---

https://github.com/user-attachments/assets/9f0b9694-cd6f-43f7-81d4-4699cff31a19

